### PR TITLE
Added README & Improved TinyMCE Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# nova-tinymce-field
+This package is a Nova WYSIWIG Field that uses TinyMCE, which has an extensive set of configuration/plugins.
+
+### Installation
+- `composer require bythepixel/nova-tinymce-field`
+
+### Configuration
+See: https://www.tiny.cloud/docs/configure/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ This package is a Nova WYSIWIG Field that uses TinyMCE, which has an extensive s
 
 ### Installation
 - `composer require bythepixel/nova-tinymce-field`
+- `php artisan vendor:publish --provider="Bythepixel\\NovaTinymceField\\FieldServiceProvider"`
 
 ### Configuration
 See: https://www.tiny.cloud/docs/configure/

--- a/config/nova-tinymce-field.php
+++ b/config/nova-tinymce-field.php
@@ -8,11 +8,14 @@
 return [
     'options' => [
         'init' => [
+            'allow_html_in_named_anchor' => false,
             'branding' => false,
+            'extended_valid_elements' => 'a[href]',
             'image_caption' => true,
             'menubar' => false,
-            'paste_as_text' => true,
-            'paste_word_valid_elements' => 'b,strong,i,em,h1,h2',
+            'paste_as_text' => false,
+            'paste_retain_style_properties' => false,
+            'valid_elements' => '*',
         ],
         'plugins' => [
             'advlist autolink lists link image imagetools media',

--- a/config/nova-tinymce-field.php
+++ b/config/nova-tinymce-field.php
@@ -1,11 +1,16 @@
 <?php
 
+/**
+ * Nova TinyMCE Configuration
+ *
+ * For more details, see: https://www.tiny.cloud/docs/configure/
+ */
 return [
     'options' => [
         'init' => [
-            'menubar' => false,
             'branding' => false,
             'image_caption' => true,
+            'menubar' => false,
             'paste_as_text' => true,
             'paste_word_valid_elements' => 'b,strong,i,em,h1,h2',
         ],


### PR DESCRIPTION
## Overview
I added a `README.md` to the project and added a comment to `config/nova-tinymce-field.php` that links to the TinyMCE configuration documentation.

I also added the publish command to the Installation section of the README
```
php artisan vendor:publish --provider="Bythepixel\\NovaTinymceField\\FieldServiceProvider"
```

I also improved the default TinyMCE configuration to better persist non-breaking Microsoft Word formatting when copy-pasting from Word into the WYSIWIG 🐒  