### PR TITLE
Fixed Configuration Disallowing img[src] Attributes

### DIFF
--- a/config/nova-tinymce-field.php
+++ b/config/nova-tinymce-field.php
@@ -11,7 +11,7 @@ return [
         'init' => [
             'allow_html_in_named_anchor' => false,
             'branding' => false,
-            'extended_valid_elements' => 'a[href],img[*]',
+            'extended_valid_elements' => 'a[data-*|href|rel|target],img[*]',
             'image_caption' => true,
             'menubar' => false,
             'paste_as_text' => false,

--- a/config/nova-tinymce-field.php
+++ b/config/nova-tinymce-field.php
@@ -11,7 +11,7 @@ return [
         'init' => [
             'allow_html_in_named_anchor' => false,
             'branding' => false,
-            'extended_valid_elements' => 'a[href]',
+            'extended_valid_elements' => 'a[href],img[*]',
             'image_caption' => true,
             'menubar' => false,
             'paste_as_text' => false,


### PR DESCRIPTION
## Overview
I allowed all `<img>` element attributes in default TinyMCE configuration.

My recent change to improve Word Paste Formatting broke the `Insert/Edit Image` toolbar button. Attempting to insert an image into WYSIWIG content will fail because the html will be `<img/>`.

This is caused by not whitelisting the `img[src]` attribute, which is how the button inserts the image into the content.

For good measure, I added the whitelist as `img[*]` (all attributes) so that if some plugin were to use the `data-src` attribute, it would not be stripped out. Alternatively we could also compile a list of attributes we want to allow on `<img>` tags 🐒 